### PR TITLE
Prevent version conflict error

### DIFF
--- a/polymorphic/__init__.py
+++ b/polymorphic/__init__.py
@@ -6,9 +6,5 @@ This code and affiliated files are (C) by Bert Constantin and individual contrib
 Please see LICENSE and AUTHORS for more information.
 """
 
-import pkg_resources
 
-try:
-    __version__ = pkg_resources.require("django-polymorphic")[0].version
-except pkg_resources.DistributionNotFound:
-    __version__ = None  # for RTD among others
+__version__ = "3.1.0"


### PR DESCRIPTION
If you have any version conflicts, the mechanism to determine the version fails. Another alternative would be to catch the error and log a warning, but I think that would be too much logic to simply determine the version.
No security concerns.